### PR TITLE
Implement Monolog logging

### DIFF
--- a/code/emailscan.php
+++ b/code/emailscan.php
@@ -3,9 +3,19 @@ require 'vendor/autoload.php';
 
 use App\MailScanner;
 use Dotenv\Dotenv;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
 
 $host = 'imap.gmail.com';
 $port = '993';
+
+// Setup Monolog logger
+$logDir = __DIR__ . '/logs';
+if (!is_dir($logDir)) {
+    mkdir($logDir, 0777, true);
+}
+$logger = new Logger('emailscan');
+$logger->pushHandler(new StreamHandler($logDir . '/emailscan.log', Logger::INFO));
 
 $dotenv = Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();
@@ -16,6 +26,17 @@ $openai = $_ENV['OPENAI_API_KEY'] ?? null;
 $model  = $_ENV['OPENAI_MODEL'] ?? 'gpt-3.5-turbo';
 $lastFile = __DIR__.'/../docs/last_scan.json';
 
-$scanner = new MailScanner($host, $port, $username, $password, $openai, $lastFile, $model, function($m){ echo $m."\n"; });
+$scanner = new MailScanner(
+    $host,
+    $port,
+    $username,
+    $password,
+    $openai,
+    $lastFile,
+    $model,
+    function ($m) use ($logger) {
+        $logger->info($m);
+    }
+);
 $scanner->scan();
 


### PR DESCRIPTION
## Summary
- add Monolog dependencies to emailscan script
- write log output for MailScanner using Monolog

## Testing
- `php -l code/emailscan.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68486ef6663c8320a0452be4604022bb