### PR TITLE
Add example script to fetch latest email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Email Clear
+
+This repository provides a few simple utilities for connecting to an IMAP inbox.
+
+## Fetching a single email
+
+The `code/mailfetch.php` script can be used to verify that the application is able to connect to your mailbox. It will retrieve the latest email from the `INBOX` folder and print its subject.
+
+1. Copy `code/.env.example` to `code/.env` and provide your IMAP credentials.
+2. Install dependencies with `composer install --no-dev --ignore-platform-reqs`.
+3. Run the script:
+
+```bash
+php code/mailfetch.php
+```
+
+If the connection is successful, the subject of the fetched message will be displayed.

--- a/code/mailfetch.php
+++ b/code/mailfetch.php
@@ -1,0 +1,35 @@
+<?php
+require 'vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use Webklex\PHPIMAP\ClientManager;
+
+$host = 'imap.gmail.com';
+$port = '993';
+
+$dotenv = Dotenv::createImmutable(__DIR__);
+$dotenv->safeLoad();
+
+$username = $_ENV['USERNAME'] ?? null;
+$password = $_ENV['PASSWORD'] ?? null;
+
+$client = (new ClientManager())->make([
+    'host'          => $host,
+    'port'          => $port,
+    'encryption'    => 'ssl',
+    'validate_cert' => true,
+    'username'      => $username,
+    'password'      => $password,
+    'protocol'      => 'imap'
+]);
+
+$client->connect();
+$inbox = $client->getFolder('INBOX');
+$message = $inbox->messages()->limit(1)->get()->first();
+
+if ($message) {
+    echo "Subject: " . $message->getSubject() . PHP_EOL;
+} else {
+    echo "No messages found." . PHP_EOL;
+}
+


### PR DESCRIPTION
## Summary
- add README with basic usage
- add `mailfetch.php` to demonstrate connecting to the inbox

## Testing
- `php -l mailfetch.php`
- `php mailfetch.php` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848879054288320a338b36e51909dda