### PR TITLE
Add OAuth2 IMAP example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ This repository provides a few simple utilities for connecting to an IMAP inbox.
 
 ## Fetching a single email
 
-The `code/mailfetch.php` script can be used to verify that the application is able to connect to your mailbox. It will retrieve the latest email from the `INBOX` folder and print its subject.
+The `code/mailfetch.php` script can be used to verify that the application is able to connect to your mailbox using IMAP. It reads an OAuth2 access token from `code/data/token.json` and refreshes it when needed.
 
-1. Copy `code/.env.example` to `code/.env` and provide your IMAP credentials.
-2. Install dependencies with `composer install --no-dev --ignore-platform-reqs`.
-3. Run the script:
+1. Copy `code/.env.example` to `code/.env` and set the `USERNAME` variable to
+   your Gmail address.
+2. Generate an OAuth2 token using `code/onetime.php` and place the resulting
+   `token.json` file in `code/data/`.
+3. Install dependencies with `composer install --no-dev --ignore-platform-reqs`.
+4. Run the script:
 
 ```bash
 php code/mailfetch.php

--- a/code/.env.example
+++ b/code/.env.example
@@ -1,4 +1,3 @@
 USERNAME='*******************'
-PASSWORD='*******************'
 OPENAI_API_KEY=blah
 OPENAI_MODEL=blah

--- a/code/mailfetch.php
+++ b/code/mailfetch.php
@@ -2,7 +2,7 @@
 require 'vendor/autoload.php';
 
 use Dotenv\Dotenv;
-use Webklex\PHPIMAP\ClientManager;
+use GuzzleHttp\Client as HttpClient;
 
 $host = 'imap.gmail.com';
 $port = '993';
@@ -11,25 +11,71 @@ $dotenv = Dotenv::createImmutable(__DIR__);
 $dotenv->safeLoad();
 
 $username = $_ENV['USERNAME'] ?? null;
-$password = $_ENV['PASSWORD'] ?? null;
 
-$client = (new ClientManager())->make([
-    'host'          => $host,
-    'port'          => $port,
-    'encryption'    => 'ssl',
-    'validate_cert' => true,
-    'username'      => $username,
-    'password'      => $password,
-    'protocol'      => 'imap'
-]);
+// Path to OAuth2 credentials and saved token
+$clientSecret = __DIR__ . '/data/client_secret.json';
+$tokenPath    = __DIR__ . '/data/token.json';
 
-$client->connect();
-$inbox = $client->getFolder('INBOX');
-$message = $inbox->messages()->limit(1)->get()->first();
-
-if ($message) {
-    echo "Subject: " . $message->getSubject() . PHP_EOL;
-} else {
-    echo "No messages found." . PHP_EOL;
+if (!file_exists($tokenPath)) {
+    echo "Token file not found." . PHP_EOL;
+    exit(1);
 }
+
+$token = json_decode(file_get_contents($tokenPath), true);
+
+if (!$token) {
+    echo "Invalid token file." . PHP_EOL;
+    exit(1);
+}
+
+// Refresh the token if it is expired and a refresh token is available
+$expiry = ($token['created'] ?? 0) + ($token['expires_in'] ?? 0) - 60;
+if (time() >= $expiry && isset($token['refresh_token'])) {
+    $secret = json_decode(file_get_contents($clientSecret), true);
+    $cfg = $secret['installed'] ?? $secret['web'] ?? [];
+    $tokenUri = $cfg['token_uri'] ?? 'https://oauth2.googleapis.com/token';
+
+    $http = new HttpClient();
+    $response = $http->post($tokenUri, [
+        'form_params' => [
+            'client_id'     => $cfg['client_id'] ?? '',
+            'client_secret' => $cfg['client_secret'] ?? '',
+            'refresh_token' => $token['refresh_token'],
+            'grant_type'    => 'refresh_token',
+        ],
+    ]);
+
+    $new = json_decode($response->getBody(), true);
+    if (isset($new['access_token'])) {
+        $token['access_token'] = $new['access_token'];
+        $token['expires_in']   = $new['expires_in'] ?? 3600;
+        $token['created']      = time();
+        file_put_contents($tokenPath, json_encode($token));
+    }
+}
+
+// Extract the access token for IMAP authentication
+$oauthToken = $token['access_token'] ?? null;
+
+// Connect via PHP's IMAP extension using XOAUTH2
+$imapPath = sprintf('{%s:%s/imap/ssl/validate-cert/auth=XOAUTH2}INBOX', $host, $port);
+$connection = imap_open($imapPath, $username, $oauthToken, 0, 1, ['DISABLE_AUTHENTICATOR' => 'GSSAPI']);
+
+if ($connection === false) {
+    echo 'Failed to connect: ' . imap_last_error() . PHP_EOL;
+    exit(1);
+}
+
+$emails = imap_search($connection, 'ALL');
+if ($emails) {
+    rsort($emails);
+    $emailNumber = $emails[0];
+    $overview = imap_fetch_overview($connection, $emailNumber, 0);
+    $subject = $overview[0]->subject ?? '(no subject)';
+    echo 'Subject: ' . $subject . PHP_EOL;
+} else {
+    echo 'No messages found.' . PHP_EOL;
+}
+
+imap_close($connection);
 


### PR DESCRIPTION
## Summary
- document OAuth2 token handling for IMAP
- remove unused password from `.env.example`
- refresh OAuth2 token with Guzzle and use it for `imap_open`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6848978f52e88320839bd1a439786ab0