### PR TITLE
Fix GmailController token persistence

### DIFF
--- a/code/app/Http/Controllers/GmailController.php
+++ b/code/app/Http/Controllers/GmailController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\GmailToken;
 use Illuminate\Http\Request;
 
 use App\Models\UserToken;
-use Illuminate\Http\Request;
+
 use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -48,6 +47,7 @@ class GmailController extends Controller
 
         Auth::user()->tokens()->create([
             'email' => $googleUser->email,
+            'refresh_token' => $googleUser->refreshToken,
             'token' => $token,
         ]);
 

--- a/code/app/Models/UserToken.php
+++ b/code/app/Models/UserToken.php
@@ -17,6 +17,7 @@ class UserToken extends Model
      */
     protected $fillable = [
         'user_id',
+        'token',
         'refresh_token',
         'email',
         'last_scanned_at',


### PR DESCRIPTION
## Summary
- clean up imports in GmailController
- save refresh token when creating UserToken
- allow token JSON to be mass assigned

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684918173fd0832096dd32e86c14b202