### PR TITLE
Fix Gmail controller redirect route

### DIFF
--- a/code/app/Http/Controllers/Settings/GmailController.php
+++ b/code/app/Http/Controllers/Settings/GmailController.php
@@ -46,7 +46,7 @@ class GmailController extends Controller
             'refresh_token' => $token['refresh_token'] ?? ($token['access_token'] ?? ''),
         ]);
 
-        return to_route('settings.gmail.edit');
+        return to_route('gmail.edit');
     }
 
     /**


### PR DESCRIPTION
## Summary
- correct GmailController redirect to use `gmail.edit` route

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6849d41fce608320953ac422b1f6bd45