### PR TITLE
Add admin user and site content management

### DIFF
--- a/code/app/Console/Commands/CreateUser.php
+++ b/code/app/Console/Commands/CreateUser.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+
+class CreateUser extends Command
+{
+    protected $signature = 'user:create {--admin}';
+
+    protected $description = 'Create a user account';
+
+    public function handle(): int
+    {
+        $name = $this->ask('Name');
+        $email = $this->ask('Email');
+        $password = $this->secret('Password');
+
+        $user = User::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make($password),
+            'is_admin' => $this->option('admin'),
+        ]);
+
+        $this->info('User created: '.$user->id);
+
+        return self::SUCCESS;
+    }
+}

--- a/code/app/Console/Kernel.php
+++ b/code/app/Console/Kernel.php
@@ -9,6 +9,7 @@ class Kernel extends ConsoleKernel
 {
     protected $commands = [
         \App\Console\Commands\GmailScan::class,
+        \App\Console\Commands\CreateUser::class,
     ];
 
     protected function schedule(Schedule $schedule): void

--- a/code/app/Http/Controllers/Admin/SiteContentController.php
+++ b/code/app/Http/Controllers/Admin/SiteContentController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SiteContentController extends Controller
+{
+    public function edit(): Response
+    {
+        return Inertia::render('admin/SiteContent', [
+            'frontPageText' => Setting::value('front_page_text'),
+            'pricing' => Setting::value('pricing'),
+        ]);
+    }
+
+    public function update(Request $request)
+    {
+        $data = $request->validate([
+            'front_page_text' => ['nullable', 'string'],
+            'pricing' => ['nullable', 'string'],
+        ]);
+
+        foreach ($data as $key => $value) {
+            Setting::updateOrCreate(['key' => $key], ['value' => $value]);
+        }
+
+        return back();
+    }
+}

--- a/code/app/Http/Middleware/IsAdmin.php
+++ b/code/app/Http/Middleware/IsAdmin.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class IsAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!$request->user() || !$request->user()->isAdmin()) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/code/app/Models/Setting.php
+++ b/code/app/Models/Setting.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+}

--- a/code/app/Models/User.php
+++ b/code/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'email',
         'password',
         'plan',
+        'is_admin',
     ];
 
     /**
@@ -45,6 +46,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 
@@ -71,5 +73,10 @@ class User extends Authenticatable
     public function tokens()
     {
         return $this->hasMany(UserToken::class);
+    }
+
+    public function isAdmin(): bool
+    {
+        return (bool) $this->is_admin;
     }
 }

--- a/code/database/factories/UserFactory.php
+++ b/code/database/factories/UserFactory.php
@@ -29,6 +29,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'is_admin' => false,
         ];
     }
 

--- a/code/database/migrations/2024_07_01_000005_add_is_admin_to_users_table.php
+++ b/code/database/migrations/2024_07_01_000005_add_is_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/code/database/migrations/2024_07_01_000006_create_settings_table.php
+++ b/code/database/migrations/2024_07_01_000006_create_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/code/database/seeders/DatabaseSeeder.php
+++ b/code/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'is_admin' => false,
         ]);
     }
 }

--- a/code/resources/js/components/UserMenuContent.vue
+++ b/code/resources/js/components/UserMenuContent.vue
@@ -30,6 +30,11 @@ defineProps<Props>();
                 Settings
             </Link>
         </DropdownMenuItem>
+        <DropdownMenuItem v-if="user.is_admin" :as-child="true">
+            <Link class="block w-full" :href="route('admin.content.edit')" prefetch as="button">
+                Admin
+            </Link>
+        </DropdownMenuItem>
     </DropdownMenuGroup>
     <DropdownMenuSeparator />
     <DropdownMenuItem :as-child="true">

--- a/code/resources/js/pages/Welcome.vue
+++ b/code/resources/js/pages/Welcome.vue
@@ -1,5 +1,12 @@
 <script setup lang="ts">
 import { Head, Link } from '@inertiajs/vue3';
+
+interface Props {
+    frontPageText: string | null;
+    pricing: string | null;
+}
+
+const props = defineProps<Props>();
 </script>
 
 <template>
@@ -39,12 +46,11 @@ import { Head, Link } from '@inertiajs/vue3';
                     class="rounded-lg bg-white p-6 pb-12 text-[13px] leading-[20px] shadow-[inset_0px_0px_0px_1px_rgba(26,26,0,0.16)] lg:p-20 dark:bg-[#161615] dark:text-[#EDEDEC] dark:shadow-[inset_0px_0px_0px_1px_#fffaed2d]"
                 >
                     <h1 class="mb-1 font-medium">Email overload is real</h1>
-                    <p class="mb-2 text-[#706f6c] dark:text-[#A1A09A]">
-                        Unwanted emails clutter your inbox, create distractions and waste time.
-                    </p>
-                    <p class="mb-4 text-[#706f6c] dark:text-[#A1A09A]">
-                        Email Clear labels solicitation messages so you can keep your inbox tidy.
-                    </p>
+                    <p
+                        v-if="props.frontPageText"
+                        class="mb-4 text-[#706f6c] dark:text-[#A1A09A]"
+                        v-html="props.frontPageText"
+                    ></p>
                 </section>
 
                 <section
@@ -60,19 +66,7 @@ import { Head, Link } from '@inertiajs/vue3';
                     class="rounded-lg bg-white p-6 pb-12 text-[13px] leading-[20px] shadow-[inset_0px_0px_0px_1px_rgba(26,26,0,0.16)] lg:p-20 dark:bg-[#161615] dark:text-[#EDEDEC] dark:shadow-[inset_0px_0px_0px_1px_#fffaed2d]"
                 >
                     <h2 class="mb-4 font-medium">Pricing</h2>
-                    <div class="grid gap-4 text-center sm:grid-cols-3">
-                        <div class="rounded-md border p-4">
-                            <h3 class="font-semibold">Free</h3>
-                        </div>
-                        <div class="rounded-md border p-4">
-                            <h3 class="font-semibold">Pro</h3>
-                            <p class="text-sm text-[#706f6c] dark:text-[#A1A09A]">$9 / month</p>
-                        </div>
-                        <div class="rounded-md border p-4">
-                            <h3 class="font-semibold">Super</h3>
-                            <p class="text-sm text-[#706f6c] dark:text-[#A1A09A]">$19 / month</p>
-                        </div>
-                    </div>
+                    <div v-if="props.pricing" v-html="props.pricing"></div>
                 </section>
             </main>
         </div>

--- a/code/resources/js/pages/admin/SiteContent.vue
+++ b/code/resources/js/pages/admin/SiteContent.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import { Button } from '@/components/ui/button';
+import { Head, useForm } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+
+interface Props {
+    frontPageText: string | null;
+    pricing: string | null;
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    {
+        title: 'Admin',
+        href: '/admin/content',
+    },
+];
+
+const form = useForm({
+    front_page_text: props.frontPageText || '',
+    pricing: props.pricing || '',
+});
+
+const submit = () => {
+    form.post(route('admin.content.update'));
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Site Content" />
+        <div class="space-y-6 p-4">
+            <HeadingSmall title="Site Content" />
+            <form @submit.prevent="submit" class="space-y-4">
+                <div class="grid gap-2">
+                    <label for="front_page_text">Front page text</label>
+                    <textarea id="front_page_text" class="w-full border" rows="3" v-model="form.front_page_text" />
+                </div>
+                <div class="grid gap-2">
+                    <label for="pricing">Pricing</label>
+                    <textarea id="pricing" class="w-full border" rows="3" v-model="form.pricing" />
+                </div>
+                <Button type="submit">Save</Button>
+            </form>
+        </div>
+    </AppLayout>
+</template>

--- a/code/resources/js/types/index.d.ts
+++ b/code/resources/js/types/index.d.ts
@@ -30,6 +30,7 @@ export interface User {
     name: string;
     email: string;
     avatar?: string;
+    is_admin: boolean;
     email_verified_at: string | null;
     created_at: string;
     updated_at: string;

--- a/code/routes/web.php
+++ b/code/routes/web.php
@@ -2,9 +2,15 @@
 
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
+use App\Models\Setting;
+use App\Http\Middleware\IsAdmin;
+use App\Http\Controllers\Admin\SiteContentController;
 
 Route::get('/', function () {
-    return Inertia::render('Welcome');
+    return Inertia::render('Welcome', [
+        'frontPageText' => Setting::value('front_page_text'),
+        'pricing' => Setting::value('pricing'),
+    ]);
 })->name('home');
 
 Route::get('dashboard', function () {
@@ -13,3 +19,8 @@ Route::get('dashboard', function () {
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';
+
+Route::middleware(['auth', IsAdmin::class])->group(function () {
+    Route::get('admin/content', [SiteContentController::class, 'edit'])->name('admin.content.edit');
+    Route::post('admin/content', [SiteContentController::class, 'update'])->name('admin.content.update');
+});


### PR DESCRIPTION
## Summary
- introduce `is_admin` field and `Setting` model
- allow editing of site content in new admin page
- secure admin routes with new `IsAdmin` middleware
- update landing page to load dynamic content
- add `user:create` artisan command for creating users

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6849df1a420483208ac4fa21937c9289