### PR TITLE
Fix success feedback after saving settings

### DIFF
--- a/code/app/Http/Controllers/Admin/SiteContentController.php
+++ b/code/app/Http/Controllers/Admin/SiteContentController.php
@@ -32,6 +32,6 @@ class SiteContentController extends Controller
             Setting::updateOrCreate(['key' => $key], ['value' => $value]);
         }
 
-        return back();
+        return back(303);
     }
 }

--- a/code/app/Http/Controllers/GmailController.php
+++ b/code/app/Http/Controllers/GmailController.php
@@ -37,7 +37,7 @@ class GmailController extends Controller
             'token' => $token,
         ]);
 
-        return redirect()->route('gmail.edit');
+        return redirect()->route('gmail.edit', status: 303);
     }
 
     public function edit(): Response
@@ -53,6 +53,6 @@ class GmailController extends Controller
     {
         $token->delete();
 
-        return back();
+        return back(303);
     }
 }

--- a/code/app/Http/Controllers/Settings/GmailController.php
+++ b/code/app/Http/Controllers/Settings/GmailController.php
@@ -46,7 +46,7 @@ class GmailController extends Controller
             'refresh_token' => $token['refresh_token'] ?? ($token['access_token'] ?? ''),
         ]);
 
-        return to_route('gmail.edit');
+        return to_route('gmail.edit', [], 303);
     }
 
     /**
@@ -58,7 +58,7 @@ class GmailController extends Controller
         if ($token) {
             $token->delete();
         }
-        return back();
+        return back(303);
     }
 
     protected function makeClient(): Google_Client

--- a/code/app/Http/Controllers/Settings/PasswordController.php
+++ b/code/app/Http/Controllers/Settings/PasswordController.php
@@ -34,6 +34,6 @@ class PasswordController extends Controller
             'password' => Hash::make($validated['password']),
         ]);
 
-        return back();
+        return back(303);
     }
 }

--- a/code/app/Http/Controllers/Settings/ProfileController.php
+++ b/code/app/Http/Controllers/Settings/ProfileController.php
@@ -37,7 +37,7 @@ class ProfileController extends Controller
 
         $request->user()->save();
 
-        return to_route('profile.edit');
+        return to_route('profile.edit', [], 303);
     }
 
     /**


### PR DESCRIPTION
## Summary
- return HTTP 303 on profile settings update
- return HTTP 303 on password update
- return HTTP 303 for Gmail callback and disconnect
- return HTTP 303 for admin content updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a1d992a988320b8f2b0bf8114363d