### PR TITLE
Add IMAP account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ displayed.
 ## Laravel integration
 
 The application under `code/` now provides a simple Gmail connection flow. After registering and verifying your account, visit `/settings/gmail` to connect your mailbox. A console command `php artisan gmail:scan` will read recent messages and update the `user_tokens` table with the last scanned time.
+
+## Standard IMAP Accounts
+
+In addition to Gmail OAuth, you can connect any standard IMAP inbox. Visit `/settings/imap` to add your server host, port, encryption type, username and password. Credentials are encrypted in the database.
+
+Run `php artisan imap:scan` to process all saved accounts using the same OpenAI powered classifier.

--- a/code/app/Console/Commands/ImapScan.php
+++ b/code/app/Console/Commands/ImapScan.php
@@ -2,26 +2,27 @@
 
 namespace App\Console\Commands;
 
-use App\Models\UserToken;
+use App\Models\ImapAccount;
 use App\Services\MailScanner;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 
-class GmailScan extends Command
+class ImapScan extends Command
 {
-    protected $signature = 'gmail:scan';
+    protected $signature = 'imap:scan';
 
-    protected $description = 'Scan Gmail accounts for solicitation emails';
+    protected $description = 'Scan standard IMAP accounts for solicitation emails';
 
     public function handle(MailScanner $scanner): int
     {
         $openai = config('services.openai.key');
         $model = config('services.openai.model', 'gpt-3.5-turbo');
-        foreach (UserToken::all() as $token) {
+
+        foreach (ImapAccount::all() as $account) {
             try {
-                $scanner->scanGmailAccount($token, $token->email, $openai, $model);
+                $scanner->scanImapAccount($account, $openai, $model);
             } catch (\Throwable $e) {
-                Log::error('scan failed: ' . $e->getMessage());
+                Log::error('imap scan failed: ' . $e->getMessage());
             }
         }
 

--- a/code/app/Http/Controllers/Settings/ImapAccountController.php
+++ b/code/app/Http/Controllers/Settings/ImapAccountController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Models\ImapAccount;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ImapAccountController extends Controller
+{
+    public function edit(Request $request): Response
+    {
+        $accounts = $request->user()->imapAccounts()->get(['id', 'host', 'username']);
+
+        return Inertia::render('settings/Imap', [
+            'accounts' => $accounts,
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'host' => ['required', 'string'],
+            'port' => ['required', 'integer', 'between:1,65535'],
+            'encryption' => ['nullable', 'in:none,ssl,tls'],
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if ($data['encryption'] === 'none') {
+            $data['encryption'] = null;
+        }
+
+        $request->user()->imapAccounts()->create($data);
+
+        return back(303);
+    }
+
+    public function destroy(ImapAccount $account): RedirectResponse
+    {
+        $account->delete();
+
+        return back(303);
+    }
+}

--- a/code/app/Models/ImapAccount.php
+++ b/code/app/Models/ImapAccount.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ImapAccount extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'host',
+        'port',
+        'encryption',
+        'username',
+        'password',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'password' => 'encrypted',
+        ];
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/code/app/Models/User.php
+++ b/code/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Models\UserToken;
+use App\Models\ImapAccount;
 
 class User extends Authenticatable
 {
@@ -73,6 +74,11 @@ class User extends Authenticatable
     public function tokens()
     {
         return $this->hasMany(UserToken::class);
+    }
+
+    public function imapAccounts()
+    {
+        return $this->hasMany(ImapAccount::class);
     }
 
     public function isAdmin(): bool

--- a/code/database/migrations/2024_07_08_000007_create_imap_accounts_table.php
+++ b/code/database/migrations/2024_07_08_000007_create_imap_accounts_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('imap_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('host');
+            $table->unsignedInteger('port');
+            $table->string('encryption')->nullable();
+            $table->string('username');
+            $table->string('password')->encrypted();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('imap_accounts');
+    }
+};

--- a/code/resources/js/layouts/settings/Layout.vue
+++ b/code/resources/js/layouts/settings/Layout.vue
@@ -22,6 +22,10 @@ const sidebarNavItems: NavItem[] = [
         title: 'Gmail',
         href: '/settings/gmail',
     },
+    {
+        title: 'IMAP',
+        href: '/settings/imap',
+    },
 ];
 
 const page = usePage();

--- a/code/resources/js/pages/settings/Imap.vue
+++ b/code/resources/js/pages/settings/Imap.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { type BreadcrumbItem } from '@/types';
+
+interface Account {
+    id: number;
+    host: string;
+    username: string;
+}
+
+interface Props {
+    accounts: Account[];
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbItems: BreadcrumbItem[] = [
+    { title: 'IMAP accounts', href: '/settings/imap' },
+];
+
+const form = useForm({
+    host: '',
+    port: 993,
+    encryption: 'ssl',
+    username: '',
+    password: '',
+});
+
+const submit = () => {
+    form.post(route('imap.store'));
+};
+
+const remove = (id: number) => {
+    form.delete(route('imap.destroy', id));
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbItems">
+        <Head title="IMAP accounts" />
+
+        <SettingsLayout>
+            <div class="space-y-6">
+                <HeadingSmall title="Existing IMAP accounts" />
+
+                <ul class="space-y-2">
+                    <li v-for="acc in props.accounts" :key="acc.id" class="flex justify-between items-center">
+                        <span>{{ acc.username }}@{{ acc.host }}</span>
+                        <Button variant="destructive" @click="remove(acc.id)">Delete</Button>
+                    </li>
+                </ul>
+
+                <HeadingSmall title="Add account" />
+
+                <form class="space-y-4" @submit.prevent="submit">
+                    <div class="flex space-x-2">
+                        <Input v-model="form.host" placeholder="Host" class="flex-1" />
+                        <Input v-model.number="form.port" placeholder="Port" class="w-24" />
+                    </div>
+                    <Input v-model="form.encryption" placeholder="Encryption (ssl/tls/none)" />
+                    <Input v-model="form.username" placeholder="Username" />
+                    <Input v-model="form.password" type="password" placeholder="Password" />
+                    <Button type="submit" :disabled="form.processing">Save</Button>
+                </form>
+            </div>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/code/routes/settings.php
+++ b/code/routes/settings.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\GmailController;
+use App\Http\Controllers\Settings\ImapAccountController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -24,4 +25,8 @@ Route::middleware('auth')->group(function () {
     Route::post('settings/gmail/connect', [GmailController::class, 'redirect'])->name('gmail.connect');
     Route::get('settings/gmail/callback', [GmailController::class, 'callback'])->name('gmail.callback');
     Route::delete('settings/gmail/{token}', [GmailController::class, 'destroy'])->name('gmail.destroy');
+
+    Route::get('settings/imap', [ImapAccountController::class, 'edit'])->name('imap.edit');
+    Route::post('settings/imap', [ImapAccountController::class, 'store'])->name('imap.store');
+    Route::delete('settings/imap/{account}', [ImapAccountController::class, 'destroy'])->name('imap.destroy');
 });


### PR DESCRIPTION
## Summary
- add migration and model for IMAP accounts
- allow users to manage IMAP accounts in settings
- update MailScanner to scan generic IMAP servers
- add `imap:scan` console command and update Gmail scan
- document IMAP setup

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_685028aab9e08320999b08d63325e2a4