### PR TITLE
Add dashboard-managed IMAP accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Email Clear
 
 This repository provides a few simple utilities for connecting to an IMAP inbox.
+While the original focus was Gmail OAuth integration, you can now scan any
+standard IMAP account by supplying a username and password.
 
 ## Token refresher
 
@@ -45,3 +47,15 @@ displayed.
 ## Laravel integration
 
 The application under `code/` now provides a simple Gmail connection flow. After registering and verifying your account, visit `/settings/gmail` to connect your mailbox. A console command `php artisan gmail:scan` will read recent messages and update the `user_tokens` table with the last scanned time.
+
+You can also manage plain IMAP accounts from the dashboard under `/settings/imap`. After adding credentials, run `php artisan imap:scan` to process each stored account.
+
+### IMAP-only usage
+
+Add account details under `/settings/imap` and then run:
+
+```bash
+php artisan imap:scan
+```
+
+Each stored account will be scanned in turn.

--- a/code/.env.example
+++ b/code/.env.example
@@ -67,6 +67,7 @@ OPENAI_MODEL=gpt-3.5-turbo
 SCANNER_MAX_MESSAGES=25
 SCANNER_THROTTLE_MS=1000
 
+
 VITE_APP_NAME="${APP_NAME}"
 
 # This google credentials file is stored in storage/app/credentials/

--- a/code/app/Console/Commands/ImapScan.php
+++ b/code/app/Console/Commands/ImapScan.php
@@ -1,0 +1,32 @@
+<?php
+namespace App\Console\Commands;
+
+use App\Services\MailScanner;
+use App\Models\ImapAccount;
+use Illuminate\Console\Command;
+
+class ImapScan extends Command
+{
+    protected $signature = 'imap:scan';
+
+    protected $description = 'Scan stored IMAP accounts for solicitation emails';
+
+    public function handle(MailScanner $scanner): int
+    {
+        $openai = config('services.openai.key');
+        $model = config('services.openai.model', 'gpt-3.5-turbo');
+
+        foreach (ImapAccount::all() as $account) {
+            $scanner->scanImap(
+                $account->host,
+                $account->port,
+                $account->encryption ?? 'ssl',
+                $account->username,
+                $account->password,
+                $openai,
+                $model
+            );
+        }
+        return self::SUCCESS;
+    }
+}

--- a/code/app/Http/Controllers/ImapAccountController.php
+++ b/code/app/Http/Controllers/ImapAccountController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ImapAccount;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ImapAccountController extends Controller
+{
+    public function index(): Response
+    {
+        $accounts = Auth::user()->imapAccounts()->get(['id', 'email']);
+
+        return Inertia::render('settings/Imap', [
+            'accounts' => $accounts,
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'email' => ['required', 'email'],
+            'host' => ['required', 'string'],
+            'port' => ['required', 'integer'],
+            'encryption' => ['nullable', 'string'],
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
+
+        $request->user()->imapAccounts()->create($data);
+
+        return back(303);
+    }
+
+    public function destroy(ImapAccount $account): RedirectResponse
+    {
+        $account->delete();
+
+        return back(303);
+    }
+}

--- a/code/app/Models/ImapAccount.php
+++ b/code/app/Models/ImapAccount.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ImapAccount extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'email',
+        'host',
+        'port',
+        'encryption',
+        'username',
+        'password',
+    ];
+
+    protected $casts = [
+        'password' => 'encrypted',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/code/app/Models/User.php
+++ b/code/app/Models/User.php
@@ -75,6 +75,14 @@ class User extends Authenticatable
         return $this->hasMany(UserToken::class);
     }
 
+    /**
+     * IMAP accounts associated with the user.
+     */
+    public function imapAccounts()
+    {
+        return $this->hasMany(ImapAccount::class);
+    }
+
     public function isAdmin(): bool
     {
         return (bool) $this->is_admin;

--- a/code/database/migrations/2025_06_16_000007_create_imap_accounts_table.php
+++ b/code/database/migrations/2025_06_16_000007_create_imap_accounts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('imap_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('email');
+            $table->string('host');
+            $table->unsignedSmallInteger('port');
+            $table->string('encryption')->nullable();
+            $table->string('username');
+            $table->text('password');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('imap_accounts');
+    }
+};

--- a/code/resources/js/layouts/settings/Layout.vue
+++ b/code/resources/js/layouts/settings/Layout.vue
@@ -22,6 +22,10 @@ const sidebarNavItems: NavItem[] = [
         title: 'Gmail',
         href: '/settings/gmail',
     },
+    {
+        title: 'IMAP',
+        href: '/settings/imap',
+    },
 ];
 
 const page = usePage();

--- a/code/resources/js/pages/settings/Imap.vue
+++ b/code/resources/js/pages/settings/Imap.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+import { Head, useForm, Link } from '@inertiajs/vue3';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { type BreadcrumbItem } from '@/types';
+
+interface Account {
+    id: number;
+    email: string;
+}
+
+interface Props {
+    accounts: Account[];
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbItems: BreadcrumbItem[] = [
+    {
+        title: 'IMAP accounts',
+        href: '/settings/imap',
+    },
+];
+
+const form = useForm({
+    email: '',
+    host: '',
+    port: 993,
+    encryption: 'ssl',
+    username: '',
+    password: '',
+});
+
+const submit = () => {
+    form.post(route('imap.store'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset('password'),
+    });
+};
+
+const remove = (id: number) => {
+    useForm({}).delete(route('imap.destroy', id));
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbItems">
+        <Head title="IMAP accounts" />
+
+        <SettingsLayout>
+            <div class="space-y-6">
+                <HeadingSmall title="Connected IMAP accounts" />
+                <ul class="space-y-2">
+                    <li v-for="account in props.accounts" :key="account.id" class="flex justify-between items-center">
+                        <span>{{ account.email }}</span>
+                        <Button variant="destructive" @click="remove(account.id)">
+                            Remove
+                        </Button>
+                    </li>
+                </ul>
+
+                <HeadingSmall title="Add IMAP account" />
+                <form @submit.prevent="submit" class="space-y-4">
+                    <div class="grid gap-2">
+                        <Label for="email">Email</Label>
+                        <Input id="email" v-model="form.email" />
+                        <InputError :message="form.errors.email" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="host">Host</Label>
+                        <Input id="host" v-model="form.host" />
+                        <InputError :message="form.errors.host" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="port">Port</Label>
+                        <Input id="port" type="number" v-model="form.port" />
+                        <InputError :message="form.errors.port" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="encryption">Encryption</Label>
+                        <Input id="encryption" v-model="form.encryption" />
+                        <InputError :message="form.errors.encryption" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="username">Username</Label>
+                        <Input id="username" v-model="form.username" />
+                        <InputError :message="form.errors.username" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="password">Password</Label>
+                        <Input id="password" type="password" v-model="form.password" />
+                        <InputError :message="form.errors.password" />
+                    </div>
+                    <Button :disabled="form.processing">Add account</Button>
+                </form>
+            </div>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/code/routes/settings.php
+++ b/code/routes/settings.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\GmailController;
+use App\Http\Controllers\ImapAccountController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -24,4 +25,8 @@ Route::middleware('auth')->group(function () {
     Route::post('settings/gmail/connect', [GmailController::class, 'redirect'])->name('gmail.connect');
     Route::get('settings/gmail/callback', [GmailController::class, 'callback'])->name('gmail.callback');
     Route::delete('settings/gmail/{token}', [GmailController::class, 'destroy'])->name('gmail.destroy');
+
+    Route::get('settings/imap', [ImapAccountController::class, 'index'])->name('imap.index');
+    Route::post('settings/imap', [ImapAccountController::class, 'store'])->name('imap.store');
+    Route::delete('settings/imap/{account}', [ImapAccountController::class, 'destroy'])->name('imap.destroy');
 });


### PR DESCRIPTION
## Summary
- document IMAP account management and scanning
- drop IMAP environment values
- create `ImapAccount` model and migration
- allow IMAP accounts to be added via settings
- update scan command to iterate over stored accounts

## Testing
- `git log -1 --stat`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685030830bbc832096bfaa2077c34d1e