### PR TITLE
Add Google config provider

### DIFF
--- a/code/app/Providers/GoogleConfigServiceProvider.php
+++ b/code/app/Providers/GoogleConfigServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class GoogleConfigServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        $path = config('services.google.credentials');
+
+        $credentials = [];
+
+        if (!env('GOOGLE_CLIENT_ID') || !env('GOOGLE_CLIENT_SECRET') || !env('GOOGLE_REDIRECT_URI')) {
+            if ($path && is_file($path)) {
+                $json = json_decode(file_get_contents($path), true);
+
+                if (isset($json['web'])) {
+                    $json = $json['web'];
+                } elseif (isset($json['installed'])) {
+                    $json = $json['installed'];
+                }
+
+                $credentials = $json ?? [];
+            }
+        }
+
+        config([
+            'services.google.client_id' => env('GOOGLE_CLIENT_ID', $credentials['client_id'] ?? null),
+            'services.google.client_secret' => env('GOOGLE_CLIENT_SECRET', $credentials['client_secret'] ?? null),
+            'services.google.redirect' => env('GOOGLE_REDIRECT_URI', $credentials['redirect_uris'][0] ?? $credentials['redirect_uri'] ?? null),
+        ]);
+    }
+}

--- a/code/bootstrap/providers.php
+++ b/code/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\GoogleConfigServiceProvider::class,
 ];


### PR DESCRIPTION
## Summary
- create `GoogleConfigServiceProvider` to load OAuth details from the JSON file configured at `services.google.credentials`
- register the provider in the bootstrap providers list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851864c5b788320a7b984c9cda09ee6