### PR TITLE
Fix Gmail connect CORS by using anchor

### DIFF
--- a/code/resources/js/pages/settings/Gmail.vue
+++ b/code/resources/js/pages/settings/Gmail.vue
@@ -50,7 +50,7 @@ const disconnect = (id: number) => {
 
                 <div>
                     <Button as-child>
-                        <Link :href="route('gmail.connect')">Connect new Gmail</Link>
+                        <a :href="route('gmail.connect')">Connect new Gmail</a>
                     </Button>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- use a normal anchor tag for Gmail connect button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68518a7095588320a26a10833338e856