### PR TITLE
Fix Gmail OAuth redirect URI handling

### DIFF
--- a/code/app/Http/Controllers/Settings/GmailController.php
+++ b/code/app/Http/Controllers/Settings/GmailController.php
@@ -68,7 +68,7 @@ class GmailController extends Controller
         $client->addScope('https://mail.google.com/');
         $client->setAccessType('offline');
         $client->setPrompt('consent');
-        $client->setRedirectUri(route('settings.gmail.callback', absolute: false));
+        $client->setRedirectUri(config('services.google.redirect'));
         return $client;
     }
 }

--- a/code/app/Providers/GoogleConfigServiceProvider.php
+++ b/code/app/Providers/GoogleConfigServiceProvider.php
@@ -37,10 +37,12 @@ class GoogleConfigServiceProvider extends ServiceProvider
             }
         }
 
+        $defaultRedirect = rtrim(config('app.url'), '/') . '/settings/gmail/callback';
+
         config([
             'services.google.client_id' => env('GOOGLE_CLIENT_ID', $credentials['client_id'] ?? null),
             'services.google.client_secret' => env('GOOGLE_CLIENT_SECRET', $credentials['client_secret'] ?? null),
-            'services.google.redirect' => env('GOOGLE_REDIRECT_URI', $credentials['redirect_uris'][0] ?? $credentials['redirect_uri'] ?? null),
+            'services.google.redirect' => env('GOOGLE_REDIRECT_URI', $credentials['redirect_uris'][0] ?? $credentials['redirect_uri'] ?? $defaultRedirect),
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- default redirect URI to app URL in GoogleConfigServiceProvider
- use configured redirect URI when creating the Google client

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68518c33449c83209d85918d4de63ca4