### PR TITLE
Add shadow Gmail callback route

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ displayed.
 
 The application under `code/` now provides a simple Gmail connection flow. After registering and verifying your account, visit `/settings/gmail` to connect your mailbox. A console command `php artisan gmail:scan` will read recent messages and update the `user_tokens` table with the last scanned time.
 
+A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/settings/gmail/callback-shadow`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
+
 You can also manage plain IMAP accounts from the dashboard under `/settings/imap`. After adding credentials, run `php artisan imap:scan` to process each stored account.
 
 ### IMAP-only usage

--- a/code/app/Http/Controllers/GmailController.php
+++ b/code/app/Http/Controllers/GmailController.php
@@ -45,6 +45,50 @@ class GmailController extends Controller
         
         return redirect()->route('gmail.edit', status: 303);
     }
+
+    public function callbackShadow(Request $request)
+    {
+        $data = $request->validate([
+            'code' => 'sometimes|string',
+            'access_token' => 'required_without:code|string',
+            'refresh_token' => 'required_without:code|string',
+            'expires_in' => 'required_without:code|integer',
+            'email' => 'sometimes|email',
+        ]);
+
+        $provider = Socialite::driver('google')->stateless();
+
+        if (isset($data['code'])) {
+            $tokenData = $provider->getAccessTokenResponse($data['code']);
+            $accessToken = $tokenData['access_token'] ?? null;
+            $refreshToken = $tokenData['refresh_token'] ?? null;
+            $expiresIn = $tokenData['expires_in'] ?? null;
+            $googleUser = $provider->userFromToken($accessToken);
+            $email = $googleUser->email;
+        } else {
+            $accessToken = $data['access_token'];
+            $refreshToken = $data['refresh_token'];
+            $expiresIn = $data['expires_in'];
+            $email = $data['email'] ?? null;
+        }
+
+        $token = [
+            'access_token' => $accessToken,
+            'refresh_token' => $refreshToken,
+            'expires_in' => $expiresIn,
+            'created' => time(),
+        ];
+
+        /** @var Illuminate\Contracts\Auth\Authenticatable */
+        $u = Auth::user();
+        $u->tokens()->create([
+            'email' => $email,
+            'refresh_token' => $refreshToken,
+            'token' => $token,
+        ]);
+
+        return redirect()->route('gmail.edit', status: 303);
+    }
     
     public function edit(): Response
     {

--- a/code/routes/settings.php
+++ b/code/routes/settings.php
@@ -24,6 +24,7 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/gmail', [GmailController::class, 'edit'])->name('gmail.edit');
     Route::get('settings/gmail/connect', [GmailController::class, 'redirect'])->name('gmail.connect');
     Route::get('settings/gmail/callback', [GmailController::class, 'callback'])->name('gmail.callback');
+    Route::post('settings/gmail/callback-shadow', [GmailController::class, 'callbackShadow'])->name('gmail.callback-shadow');
     Route::delete('settings/gmail/{token}', [GmailController::class, 'destroy'])->name('gmail.destroy');
 
     Route::get('settings/imap', [ImapAccountController::class, 'index'])->name('imap.index');


### PR DESCRIPTION
## Summary
- support shadow Gmail OAuth callback via POST
- document the new callback-shadow endpoint
- register callback-shadow route

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685284bfc4348320b6cc5b64c58132de