### PR TITLE
Implement OAuth callback relay script

### DIFF
--- a/callback/config.php
+++ b/callback/config.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'post_to' => 'http://localhost/settings/gmail/callback-shadow',
+    'redirect_to' => 'http://localhost/settings/gmail',
+];

--- a/callback/index.php
+++ b/callback/index.php
@@ -1,8 +1,28 @@
 <?php
-namespace NS;
-class CLASSNAME
-{
-    public function __construct()
-    {
-    }
+// Simple OAuth callback handler
+$config = include __DIR__ . '/config.php';
+
+$postUrl = $config['post_to'] ?? null;
+$redirectUrl = $config['redirect_to'] ?? '/';
+
+$data = [];
+if (isset($_GET['code'])) {
+    $data['code'] = $_GET['code'];
 }
+if (isset($_GET['state'])) {
+    $data['state'] = $_GET['state'];
+}
+
+if ($postUrl) {
+    $ch = curl_init($postUrl);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_exec($ch);
+    curl_close($ch);
+}
+
+header('Location: ' . $redirectUrl, true, 303);
+exit;
+
+


### PR DESCRIPTION
## Summary
- add configurable callback options
- send auth code to `/settings/gmail/callback-shadow`
- redirect browser to `/settings/gmail`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68528a2e99548320a607e191700754dc