### PR TITLE
Move Gmail callback to API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ displayed.
 
 The application under `code/` now provides a simple Gmail connection flow. After registering and verifying your account, visit `/settings/gmail` to connect your mailbox. A console command `php artisan gmail:scan` will read recent messages and update the `user_tokens` table with the last scanned time.
 
-A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/settings/gmail/callback-shadow`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
+A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/api/gmail/callback-shadow`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
 
 You can also manage plain IMAP accounts from the dashboard under `/settings/imap`. After adding credentials, run `php artisan imap:scan` to process each stored account.
 

--- a/callback/config.example.php
+++ b/callback/config.example.php
@@ -1,5 +1,5 @@
 <?php
 return [
-    'post_to' => 'http://localhost/settings/gmail/callback-shadow',
+    'post_to' => 'http://localhost/api/gmail/callback-shadow',
     'redirect_to' => 'http://localhost/settings/gmail',
 ];

--- a/code/app/Http/Controllers/Api/GmailController.php
+++ b/code/app/Http/Controllers/Api/GmailController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserToken;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
+use Laravel\Socialite\Contracts\Provider;
+use Laravel\Socialite\Facades\Socialite;
+
+class GmailController extends Controller
+{
+    public function callbackShadow(Request $request)
+    {
+        Log::info(__METHOD__);
+        $data = $request->validate([
+            'code' => 'sometimes|string',
+            'access_token' => 'required_without:code|string',
+            'refresh_token' => 'required_without:code|string',
+            'expires_in' => 'required_without:code|integer',
+            'email' => 'sometimes|email',
+        ]);
+        Log::debug(print_r($data, true));
+        /** @var Provider */
+        $provider = Socialite::driver('google');
+        $provider->stateless();
+
+        if (isset($data['code'])) {
+            $tokenData = $provider->getAccessTokenResponse($data['code']);
+            $accessToken = $tokenData['access_token'] ?? null;
+            $refreshToken = $tokenData['refresh_token'] ?? null;
+            $expiresIn = $tokenData['expires_in'] ?? null;
+            $googleUser = $provider->userFromToken($accessToken);
+            $email = $googleUser->email;
+        } else {
+            $accessToken = $data['access_token'];
+            $refreshToken = $data['refresh_token'];
+            $expiresIn = $data['expires_in'];
+            $email = $data['email'] ?? null;
+        }
+
+        $token = [
+            'access_token' => $accessToken,
+            'refresh_token' => $refreshToken,
+            'expires_in' => $expiresIn,
+            'created' => time(),
+        ];
+
+        /** @var \Illuminate\Contracts\Auth\Authenticatable */
+        $u = Auth::user();
+        Log::info(json_encode([
+            'user_id' => $u?->id,
+            'email' => $email,
+            'refresh_token' => $refreshToken,
+            'token' => $token,
+        ]));
+
+        if ($u) {
+            UserToken::create([
+                'user_id' => $u->id,
+                'email' => $email,
+                'refresh_token' => $refreshToken,
+                'token' => $token,
+            ]);
+        }
+
+        return redirect()->route('gmail.edit', status: 303);
+    }
+}

--- a/code/app/Http/Controllers/GmailController.php
+++ b/code/app/Http/Controllers/GmailController.php
@@ -46,66 +46,6 @@ class GmailController extends Controller
         return redirect()->route('gmail.edit', status: 303);
     }
     
-    public function callbackShadow(Request $request)
-    {
-        Log::info(__METHOD__);
-        $data = $request->validate([
-            'code' => 'sometimes|string',
-            'access_token' => 'required_without:code|string',
-            'refresh_token' => 'required_without:code|string',
-            'expires_in' => 'required_without:code|integer',
-            'email' => 'sometimes|email',
-        ]);
-        Log::debug(print_r($data, true));
-        /** @var Laravel\Socialite\Contracts\Provider */
-        $provider = Socialite::driver('google');
-        $provider->stateless();
-
-        if (isset($data['code'])) {
-            $tokenData = $provider->getAccessTokenResponse($data['code']);
-            $accessToken = $tokenData['access_token'] ?? null;
-            $refreshToken = $tokenData['refresh_token'] ?? null;
-            $expiresIn = $tokenData['expires_in'] ?? null;
-            $googleUser = $provider->userFromToken($accessToken);
-            $email = $googleUser->email;
-        } else {
-            $accessToken = $data['access_token'];
-            $refreshToken = $data['refresh_token'];
-            $expiresIn = $data['expires_in'];
-            $email = $data['email'] ?? null;
-        }
-
-        $token = [
-            'access_token' => $accessToken,
-            'refresh_token' => $refreshToken,
-            'expires_in' => $expiresIn,
-            'created' => time(),
-        ];
-
-        /** @var Illuminate\Contracts\Auth\Authenticatable */
-        $u = Auth::user();
-        Log::info(json_encode([
-            'user_id' => $u->id,
-            'email' => $email,
-            'refresh_token' => $refreshToken,
-            'token' => $token,
-        ]));
-
-        UserToken::create([
-            'user_id' => $u->id,
-            'email' => $email,
-            'refresh_token' => $refreshToken,
-            'token' => $token,
-        ]);
-
-        // $u->tokens()->create([
-        //     'email' => $email,
-        //     'refresh_token' => $refreshToken,
-        //     'token' => $token,
-        // ]);
-
-        return redirect()->route('gmail.edit', status: 303);
-    }
     
     public function edit(): Response
     {

--- a/code/bootstrap/app.php
+++ b/code/bootstrap/app.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/code/routes/api.php
+++ b/code/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\GmailController;
+
+Route::post('gmail/callback-shadow', [GmailController::class, 'callbackShadow'])->name('gmail.callback-shadow');

--- a/code/routes/settings.php
+++ b/code/routes/settings.php
@@ -30,5 +30,3 @@ Route::middleware('auth')->group(function () {
     Route::post('settings/imap', [ImapAccountController::class, 'store'])->name('imap.store');
     Route::delete('settings/imap/{account}', [ImapAccountController::class, 'destroy'])->name('imap.destroy');
 });
-
-Route::post('settings/gmail/callback-shadow', [GmailController::class, 'callbackShadow'])->name('gmail.callback-shadow');


### PR DESCRIPTION
## Summary
- add new `Api/GmailController` for callbackShadow
- register `/api/gmail/callback-shadow` route
- update bootstrap routing config
- update README and callback config
- remove old web route and method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68529aa793748320a60d2c4ff7a1396b