### PR TITLE
Restrict callback-shadow route

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ displayed.
 
 The application under `code/` now provides a simple Gmail connection flow. After registering and verifying your account, visit `/settings/gmail` to connect your mailbox. A console command `php artisan gmail:scan` will read recent messages and update the `user_tokens` table with the last scanned time.
 
-A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/api/gmail/callback-shadow`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
+A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/api/gmail/callback-shadow`. This endpoint is only available when `APP_ENV=local`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
 
 You can also manage plain IMAP accounts from the dashboard under `/settings/imap`. After adding credentials, run `php artisan imap:scan` to process each stored account.
 

--- a/code/app/Http/Controllers/Api/GmailController.php
+++ b/code/app/Http/Controllers/Api/GmailController.php
@@ -14,6 +14,9 @@ class GmailController extends Controller
 {
     public function callbackShadow(Request $request)
     {
+        if (env('APP_ENV') !== 'local') {
+            abort(403);
+        }
         Log::info(__METHOD__);
         $data = $request->validate([
             'user_id' => 'sometimes|integer',

--- a/code/routes/api.php
+++ b/code/routes/api.php
@@ -3,4 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\GmailController;
 
-Route::post('gmail/callback-shadow', [GmailController::class, 'callbackShadow'])->name('gmail.callback-shadow');
+if (env('APP_ENV') === 'local') {
+    Route::post('gmail/callback-shadow', [GmailController::class, 'callbackShadow'])
+        ->name('gmail.callback-shadow');
+}


### PR DESCRIPTION
## Summary
- restrict `/api/gmail/callback-shadow` route to local environment
- guard GmailController's `callbackShadow` so it only runs in local env
- document the env requirement in README

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6852b75eb4588320a5c94c61b34de34a