### PR TITLE
Update Gmail callback-shadow path

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ displayed.
 
 The application under `code/` now provides a simple Gmail connection flow. After registering and verifying your account, visit `/settings/gmail` to connect your mailbox. A console command `php artisan gmail:scan` will read recent messages and update the `user_tokens` table with the last scanned time.
 
-A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/api/gmail/callback-shadow`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
+A localhost OAuth listener may also capture the tokens or authorization code and POST them to `/api/settings/gmail/callback-shadow`. Upon receipt, the application stores the tokens and redirects back to `/settings/gmail`.
 
 You can also manage plain IMAP accounts from the dashboard under `/settings/imap`. After adding credentials, run `php artisan imap:scan` to process each stored account.
 

--- a/callback/config.example.php
+++ b/callback/config.example.php
@@ -1,5 +1,5 @@
 <?php
 return [
-    'post_to' => 'http://localhost/api/gmail/callback-shadow',
+    'post_to' => 'http://localhost/api/settings/gmail/callback-shadow',
     'redirect_to' => 'http://localhost/settings/gmail',
 ];

--- a/code/routes/api.php
+++ b/code/routes/api.php
@@ -3,4 +3,4 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\GmailController;
 
-Route::post('gmail/callback-shadow', [GmailController::class, 'callbackShadow'])->name('gmail.callback-shadow');
+Route::post('settings/gmail/callback-shadow', [GmailController::class, 'callbackShadow'])->name('gmail.callback-shadow');


### PR DESCRIPTION
## Summary
- register Gmail OAuth shadow callback under `/api/settings/gmail/callback-shadow`
- update README docs
- update callback sample config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852b78d87308320a28bf0fcc627282e