### PR TITLE
Fix token saving in Gmail API callback

### DIFF
--- a/code/app/Http/Controllers/Api/GmailController.php
+++ b/code/app/Http/Controllers/Api/GmailController.php
@@ -64,7 +64,7 @@ class GmailController extends Controller
             'user_id' => $userId,
             'email' => $email,
             'refresh_token' => $refreshToken,
-            'token' => $accessToken,
+            'token' => $token,
         ]);
 
         return redirect()->route('gmail.edit', status: 303);

--- a/code/app/Models/UserToken.php
+++ b/code/app/Models/UserToken.php
@@ -29,6 +29,7 @@ class UserToken extends Model
      * @var array<string, string>
      */
     protected $casts = [
+        'token' => 'array',
         'refresh_token' => 'encrypted',
         'last_scanned_at' => 'datetime',
     ];


### PR DESCRIPTION
## Summary
- use full token details when storing via callbackShadow
- cast the token attribute to array so it is saved as JSON

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852b7a856548320a8d82ae99ae6df37