### PR TITLE
Fix token refresh logic for MailScanner

### DIFF
--- a/code/app/Services/MailScanner.php
+++ b/code/app/Services/MailScanner.php
@@ -30,6 +30,10 @@ class MailScanner
     public function scanGmail(UserToken $token, string $username, string $openaiKey, string $model = OpenAiModels::GPT_41_NANO): void
     {
         $accessToken = $this->refreshAccessToken($token);
+        if (!$accessToken) {
+            Log::warning('Skipping scan: invalid token for ID ' . $token->id);
+            return;
+        }
 
         $client = (new ImapClientManager())->make([
             'host'           => 'imap.gmail.com',
@@ -192,13 +196,33 @@ class MailScanner
         return trim($result['choices'][0]['message']['content'] ?? '');
     }
 
-    protected function refreshAccessToken(UserToken $token): string
+    protected function refreshAccessToken(UserToken $token): ?string
     {
+        $tokenData = $token->token;
+
+        // Bail out if token column does not contain JSON
+        if (!is_array($tokenData)) {
+            Log::warning('Token column is not JSON for token ID ' . $token->id);
+            return null;
+        }
+
+        // If access token is still valid, return it
+        $expiry = ($tokenData['created'] ?? 0) + ($tokenData['expires_in'] ?? 0) - 60;
+        if (time() < $expiry && !empty($tokenData['access_token'])) {
+            return $tokenData['access_token'];
+        }
+
         $client = new \Google_Client();
         $client->setAuthConfig(config('services.google.credentials'));
         $client->setAccessType('offline');
         $client->refreshToken($token->refresh_token);
         $accessToken = $client->getAccessToken();
-        return $accessToken['access_token'];
+        $tokenData['access_token'] = $accessToken['access_token'] ?? null;
+        $tokenData['expires_in'] = $accessToken['expires_in'] ?? ($tokenData['expires_in'] ?? 3600);
+        $tokenData['created'] = time();
+        $token->token = $tokenData;
+        $token->save();
+
+        return $tokenData['access_token'];
     }
 }


### PR DESCRIPTION
## Summary
- improve defensive logic around `UserToken->token` JSON data
- avoid refreshing access token when it's still valid
- persist refreshed token data after successful refresh
- skip scanning when token data is invalid

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852bfda9a0c83208645313d754319d6