### PR TITLE
Add tailwind spacing size

### DIFF
--- a/code/resources/css/app.css
+++ b/code/resources/css/app.css
@@ -5,6 +5,7 @@
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';
 @source '../../storage/framework/views/*.php';
 
+@source inline("h-128 w-128");
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {

--- a/code/tailwind.config.js
+++ b/code/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  theme: {
+    extend: {
+      spacing: {
+        '128': '32rem',
+      },
+    },
+  },
+};
+


### PR DESCRIPTION
## Summary
- create `tailwind.config.js` to extend Tailwind spacing scale
- ensure custom `h-128` and `w-128` classes are included via `@source inline`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68546da509088320ac3a1c21e2f1625c