### PR TITLE
Add billing page skeleton

### DIFF
--- a/code/app/Http/Controllers/BillingController.php
+++ b/code/app/Http/Controllers/BillingController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Plan;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class BillingController extends Controller
+{
+    public function __invoke(): Response
+    {
+        return Inertia::render('Billing', [
+            'plans' => Plan::orderBy('price')->get(['id', 'name', 'description', 'price', 'features']),
+        ]);
+    }
+}

--- a/code/resources/js/components/AppSidebar.vue
+++ b/code/resources/js/components/AppSidebar.vue
@@ -5,7 +5,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-vue-next';
+import { BookOpen, Folder, LayoutGrid, CreditCard } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
@@ -13,6 +13,11 @@ const mainNavItems: NavItem[] = [
         title: 'Dashboard',
         href: '/dashboard',
         icon: LayoutGrid,
+    },
+    {
+        title: 'Billing',
+        href: '/billing',
+        icon: CreditCard,
     },
 ];
 

--- a/code/resources/js/layouts/settings/Layout.vue
+++ b/code/resources/js/layouts/settings/Layout.vue
@@ -26,6 +26,10 @@ const sidebarNavItems: NavItem[] = [
         title: 'IMAP',
         href: '/settings/imap',
     },
+    {
+        title: 'Billing',
+        href: '/billing',
+    },
 ];
 
 const page = usePage();

--- a/code/resources/js/pages/Billing.vue
+++ b/code/resources/js/pages/Billing.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import type { BreadcrumbItem } from '@/types';
+
+interface PlanInfo {
+    id: number;
+    name: string;
+    description: string | null;
+    price: number | null;
+    features: { data?: string[] } | string[];
+}
+
+interface Props {
+    plans: PlanInfo[];
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Billing', href: '/billing' },
+];
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Billing" />
+        <div class="mx-auto max-w-6xl space-y-8 p-4">
+            <h1 class="text-center text-3xl font-bold">Choose your plan</h1>
+            <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
+                <div
+                    v-for="plan in props.plans"
+                    :key="plan.id"
+                    :class="['relative flex flex-col items-center space-y-6 rounded-lg bg-black h-96 xw-96', plan.name === 'Pro' ? 'border border-blue-700' : 'border border-gray-600']"
+                >
+                    <div class="text-4xl font-bold">{{ plan.name }}</div>
+                    <div class="text-2xl font-bold text-gray-100">
+                        <template v-if="plan.price !== null">
+                            ${{ plan.price }}<span v-if="plan.price > 0" class="text-sm font-normal">/month</span>
+                        </template>
+                        <template v-else>Contact us</template>
+                    </div>
+                    <div class="w-full space-y-1">
+                        <div
+                            v-for="feature in (plan.features.data ?? plan.features)"
+                            :key="feature"
+                            class="flex items-center ml-8"
+                        >
+                            <svg
+                                class="mr-3 w-5 text-green-500"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                                stroke-width="1.5"
+                                stroke="currentColor"
+                            >
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                            </svg>
+                            <span>{{ feature }}</span>
+                        </div>
+                    </div>
+                    <div class="absolute bottom-6 left-1/2 -translate-x-1/2">
+                        <button class="rounded-md border border-gray-700 bg-gradient-to-r from-blue-500 to-purple-700 px-3 py-2 text-white">
+                            Checkout
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </AppLayout>
+</template>

--- a/code/routes/web.php
+++ b/code/routes/web.php
@@ -3,10 +3,13 @@
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\BillingController;
 use App\Http\Middleware\IsAdmin;
 use App\Http\Controllers\Admin\SiteContentController;
 
 Route::get('/', HomeController::class)->name('home');
+
+Route::get('billing', BillingController::class)->name('billing');
 
 Route::get('dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- add a Billing page component
- include Billing controller and route
- expose Billing in sidebar navigation and settings layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68548a9fe7a083209d629b687e687a9e