### PR TITLE
Implement basic upgrade to Pro plan

### DIFF
--- a/code/app/Http/Controllers/BillingController.php
+++ b/code/app/Http/Controllers/BillingController.php
@@ -5,13 +5,17 @@ namespace App\Http\Controllers;
 use App\Models\Plan;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Http\Request;
 
 class BillingController extends Controller
 {
-    public function __invoke(): Response
+    public function __invoke(Request $request): Response
     {
+        $user = $request->user();
+
         return Inertia::render('Billing', [
             'plans' => Plan::orderBy('price')->get(['id', 'name', 'description', 'price', 'features']),
+            'currentPlan' => $user ? $user->plan() : 'free',
         ]);
     }
 }

--- a/code/app/Http/Controllers/SubscriptionController.php
+++ b/code/app/Http/Controllers/SubscriptionController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Plan;
+use App\Models\Subscription;
+use App\Models\Charge;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class SubscriptionController extends Controller
+{
+    public function upgrade(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+        $plan = Plan::where('name', 'Pro')->firstOrFail();
+
+        Subscription::create([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'price' => $plan->price,
+            'start_at' => now(),
+            'status' => 0,
+        ]);
+
+        Charge::create([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'amount' => $plan->price,
+            'status' => 100,
+        ]);
+
+        $user->plan = 'pro';
+        $user->save();
+
+        return to_route('billing', [], 303);
+    }
+
+    public function cancel(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+        $subscription = $user->subscription;
+        if ($subscription && $subscription->status === 0) {
+            $subscription->update([
+                'end_at' => now(),
+                'status' => 2,
+            ]);
+
+            Charge::create([
+                'user_id' => $user->id,
+                'plan_id' => $subscription->plan_id,
+                'amount' => 0,
+                'status' => 501,
+            ]);
+        }
+
+        $user->plan = 'free';
+        $user->save();
+
+        return to_route('billing', [], 303);
+    }
+}

--- a/code/app/Models/Subscription.php
+++ b/code/app/Models/Subscription.php
@@ -6,5 +6,24 @@ use Illuminate\Database\Eloquent\Model;
 
 class Subscription extends Model
 {
-    //
+    protected $fillable = [
+        'user_id',
+        'plan_id',
+        'price',
+        'start_at',
+        'last_charged_at',
+        'paused_at',
+        'end_at',
+        'status',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function plan()
+    {
+        return $this->belongsTo(Plan::class);
+    }
 }

--- a/code/app/Models/User.php
+++ b/code/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Models\UserToken;
 use App\Models\Setting;
+use App\Models\Subscription;
 
 class User extends Authenticatable
 {
@@ -126,5 +127,13 @@ class User extends Authenticatable
         }
         $this->monthly_scanned += $amount;
         $this->save();
+    }
+
+    /**
+     * Active subscription for the user.
+     */
+    public function subscription()
+    {
+        return $this->hasOne(Subscription::class)->latestOfMany();
     }
 }

--- a/code/resources/js/pages/Billing.vue
+++ b/code/resources/js/pages/Billing.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/AppLayout.vue';
-import { Head } from '@inertiajs/vue3';
+import { Head, useForm } from '@inertiajs/vue3';
 import type { BreadcrumbItem } from '@/types';
 
 interface PlanInfo {
@@ -13,9 +13,19 @@ interface PlanInfo {
 
 interface Props {
     plans: PlanInfo[];
+    currentPlan: string;
 }
 
 const props = defineProps<Props>();
+const form = useForm({});
+
+const upgrade = () => {
+    form.post(route('billing.upgrade'));
+};
+
+const cancel = () => {
+    form.post(route('billing.cancel'));
+};
 
 const breadcrumbs: BreadcrumbItem[] = [
     { title: 'Billing', href: '/billing' },
@@ -27,6 +37,7 @@ const breadcrumbs: BreadcrumbItem[] = [
         <Head title="Billing" />
         <div class="mx-auto max-w-6xl space-y-8 p-4">
             <h1 class="text-center text-3xl font-bold">Choose your plan</h1>
+            <p class="text-center text-gray-400">Current plan: {{ props.currentPlan }}</p>
             <div class="grid grid-cols-1 gap-6 md:grid-cols-3">
                 <div
                     v-for="plan in props.plans"
@@ -60,9 +71,19 @@ const breadcrumbs: BreadcrumbItem[] = [
                         </div>
                     </div>
                     <div class="absolute bottom-6 left-1/2 -translate-x-1/2">
-                        <button class="rounded-md border border-gray-700 bg-gradient-to-r from-blue-500 to-purple-700 px-3 py-2 text-white">
-                            Checkout
-                        </button>
+                        <template v-if="plan.name.toLowerCase() === props.currentPlan">
+                            <span class="text-sm text-gray-400">Current Plan</span>
+                        </template>
+                        <template v-else-if="plan.name === 'Pro' && props.currentPlan === 'free'">
+                            <button class="rounded-md border border-gray-700 bg-gradient-to-r from-blue-500 to-purple-700 px-3 py-2 text-white" @click="upgrade">
+                                Upgrade
+                            </button>
+                        </template>
+                        <template v-else-if="plan.name === 'Pro' && props.currentPlan === 'pro'">
+                            <button class="rounded-md border border-gray-700 bg-gray-600 px-3 py-2 text-white" @click="cancel">
+                                Cancel
+                            </button>
+                        </template>
                     </div>
                 </div>
             </div>

--- a/code/routes/web.php
+++ b/code/routes/web.php
@@ -4,12 +4,17 @@ use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\BillingController;
+use App\Http\Controllers\SubscriptionController;
 use App\Http\Middleware\IsAdmin;
 use App\Http\Controllers\Admin\SiteContentController;
 
 Route::get('/', HomeController::class)->name('home');
 
 Route::get('billing', BillingController::class)->name('billing');
+Route::middleware('auth')->group(function () {
+    Route::post('billing/upgrade', [SubscriptionController::class, 'upgrade'])->name('billing.upgrade');
+    Route::post('billing/cancel', [SubscriptionController::class, 'cancel'])->name('billing.cancel');
+});
 
 Route::get('dashboard', function () {
     return Inertia::render('Dashboard');


### PR DESCRIPTION
## Summary
- add subscription management controller
- expose `currentPlan` in BillingController
- add upgrade & cancel routes
- show current plan and upgrade/cancel buttons on Billing page
- store subscription data in DB

## Testing
- `php -l code/app/Models/User.php`
- `php -l code/app/Models/Subscription.php`
- `php -l code/app/Http/Controllers/SubscriptionController.php`
- `php -l code/app/Http/Controllers/BillingController.php`
- `php -l code/routes/web.php`


------
https://chatgpt.com/codex/tasks/task_e_6854a241c1688320ad05b575ecaeecda