### PR TITLE
Fix CSRF token for billing checkout

### DIFF
--- a/code/resources/js/pages/BillingCheckout.vue
+++ b/code/resources/js/pages/BillingCheckout.vue
@@ -29,7 +29,14 @@ const breadcrumbs: BreadcrumbItem[] = [
 onMounted(async () => {
     stripe = await loadStripe(props.publishableKey);
     if (!stripe) return;
-    const resp = await fetch(route('billing.intent'), { method: 'POST' });
+    const token =
+        document.querySelector("meta[name='csrf-token']")?.getAttribute('content');
+    const resp = await fetch(route('billing.intent'), {
+        method: 'POST',
+        headers: {
+            'X-CSRF-TOKEN': token ?? '',
+        },
+    });
     const { clientSecret } = await resp.json();
     elements = stripe.elements({ clientSecret });
     const payment = elements.create('payment');

--- a/code/resources/views/app.blade.php
+++ b/code/resources/views/app.blade.php
@@ -39,6 +39,8 @@
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
 
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
         @routes
         @vite(['resources/js/app.ts', "resources/js/pages/{$page['component']}.vue"])
         @inertiaHead


### PR DESCRIPTION
## Summary
- include csrf token meta tag in `app.blade.php`
- send token in `BillingCheckout.vue` POST request

## Testing
- `php -l code/app/Console/Kernel.php`
- `php -l code/app/Http/Controllers/SubscriptionController.php`


------
https://chatgpt.com/codex/tasks/task_e_68551197d0dc83209d77b25ee01777fb