### PR TITLE
Fix CLI error output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,16 @@
+import argparse
+import re
+
+class SilentParser(argparse.ArgumentParser):
+    def error(self, message):
+        self.exit(2, f"{self.prog}: error: {message}\n")
+
+def valid_email(value: str) -> str:
+    if not re.match(r"^[^@]+@[^@]+\.[^@]+$", value):
+        raise argparse.ArgumentTypeError("bad email syntax")
+    return value
+
+parser = SilentParser(description="Email Clear CLI")
+parser.add_argument("email", type=valid_email, help="Email address to process")
+args = parser.parse_args()
+print(f"Processing {args.email}")


### PR DESCRIPTION
## Summary
- add a new cli script that validates email addresses
- suppress argparse usage output when validation fails

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859bc103a988320906cb66e09896523